### PR TITLE
:construction_worker: updated to write to the new GITHUB_OUTPUT envir…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: '16'
       - name: Yarn cache directory
         id: yarn-cache-dir
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - name: cache yarn modules
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
…onment file

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/